### PR TITLE
Fix warning for unused local variable

### DIFF
--- a/lib/reflect/reflection.rb
+++ b/lib/reflect/reflection.rb
@@ -24,7 +24,7 @@ module Reflect
       target = Reflect.get_constant(subject_constant, constant_name, strict: strict, ancestors: ancestors)
       return nil if target.nil?
 
-      instance = new(subject, target, strict)
+      new(subject, target, strict)
     end
 
     def call(method_name, arg=nil)


### PR DESCRIPTION
I'm using evt-configure and evt-dependency in a small project and noticed after I added them that my tests started complaining:

```
$ rake
/Users/mikejudge/.asdf/installs/ruby/2.6.2/lib/ruby/gems/2.6.0/gems/evt-reflect-2.2.0.0/lib/reflect/reflection.rb:27: warning: assigned but unused variable - instance
Run options: --seed 39504

# Running:

......................................

Finished in 0.007276s, 5222.6498 runs/s, 7696.5366 assertions/s.
38 runs, 56 assertions, 0 failures, 0 errors, 0 skips
```

I figured it'd take as long to file an issue as to fork and fix it, so here's a fix.